### PR TITLE
Spectate fixes, ESP look arrows + admin highlight, and a player flag …

### DIFF
--- a/4_World/VPPAdminTools/Plugins/PluginBase/EspTools/VPPESPTools.c
+++ b/4_World/VPPAdminTools/Plugins/PluginBase/EspTools/VPPESPTools.c
@@ -8,6 +8,20 @@ class VPPESPTools extends PluginBase
 		GetRPCManager().AddRPC( "RPC_VPPESPTools", "RetriveCodeFromObj", this, SingeplayerExecutionType.Server );
 		GetRPCManager().AddRPC( "RPC_VPPESPTools", "ToggleMeshESP", this, SingeplayerExecutionType.Server );
 		GetRPCManager().AddRPC( "RPC_VPPESPTools", "BringReturnObj", this, SingeplayerExecutionType.Server );
+		GetRPCManager().AddRPC( "RPC_VPPESPTools", "GetAdminIds", this, SingeplayerExecutionType.Server );
+	}
+
+	//Send the list of superadmin/usergroup steam64 ids so the ESP can highlight admins
+	void GetAdminIds(CallType type, ParamsReadContext ctx, PlayerIdentity sender, Object target)
+	{
+		if (type == CallType.Server && sender != null)
+		{
+			if (!GetPermissionManager().VerifyPermission(sender.GetPlainId(), "EspToolsMenu", "", false))
+				return;
+
+			array<string> ids = GetPermissionManager().GetAllAdminIds();
+			GetRPCManager().VSendRPC("RPC_VPPESPTools", "HandleAdminIds", new Param1<ref array<string>>(ids), true, sender);
+		}
 	}
 	
 	void BringReturnObj(CallType type, ParamsReadContext ctx, PlayerIdentity sender, Object target)

--- a/4_World/VPPAdminTools/Plugins/PluginBase/PermissionManager/PermissionManager.c
+++ b/4_World/VPPAdminTools/Plugins/PluginBase/PermissionManager/PermissionManager.c
@@ -686,6 +686,34 @@ class PermissionManager extends ConfigurablePlugin
 		CloseFile(adminUIDSFile);
 	}
 		
+	//All admin steam64 ids: superadmins + every user group member (used for ESP admin highlight)
+	array<string> GetAllAdminIds()
+	{
+		array<string> ids = new array<string>;
+		foreach(string sid : m_SuperAdmins)
+		{
+			if (ids.Find(sid) == -1)
+				ids.Insert(sid);
+		}
+
+		foreach(UserGroup adminGroup : m_UserGroups)
+		{
+			if (!adminGroup)
+				continue;
+
+			array<ref VPPUser> members = adminGroup.GetMembers();
+			if (!members)
+				continue;
+
+			foreach(VPPUser member : members)
+			{
+				if (member && ids.Find(member.GetUserId()) == -1)
+					ids.Insert(member.GetUserId());
+			}
+		}
+		return ids;
+	}
+
 	bool HasUserGroup(string id)
 	{
 		foreach(UserGroup group : m_UserGroups)

--- a/5_Mission/VPPAdminTools/GUI/SubMenus/MenuEspTools/Classes/VPPESPTracker.c
+++ b/5_Mission/VPPAdminTools/GUI/SubMenus/MenuEspTools/Classes/VPPESPTracker.c
@@ -139,8 +139,12 @@ class VPPESPTracker: ScriptedWidgetEventHandler
 			m_BtnKill = ButtonWidget.Cast(m_RootWidget.FindAnyWidget("BtnKill"));
 			m_BtnTpReturn = ButtonWidget.Cast(m_RootWidget.FindAnyWidget("BtnTpReturn"));
 			
-			EspToolsMenu espManager = EspToolsMenu.Cast(VPPAdminHud.Cast(GetVPPUIManager().GetMenuByType(VPPAdminHud)).GetSubMenuByType(EspToolsMenu));
-			if (!player.IsAlive() && !espManager.ShowDeadPlayers())
+			EspToolsMenu espManager;
+			VPPAdminHud initHud = VPPAdminHud.Cast(GetVPPUIManager().GetMenuByType(VPPAdminHud));
+			if (initHud)
+				espManager = EspToolsMenu.Cast(initHud.GetSubMenuByType(EspToolsMenu));
+
+			if (espManager && !player.IsAlive() && !espManager.ShowDeadPlayers())
 			{
 				espManager.RemoveTracker(this);
 				return;
@@ -284,13 +288,19 @@ class VPPESPTracker: ScriptedWidgetEventHandler
 			case m_ChkSelectPlayer:
 				MenuPlayerManager pManager;
 				VPPAdminHud rootMenu = VPPAdminHud.Cast(GetVPPUIManager().GetMenuByType(VPPAdminHud));
+				if (!rootMenu)
+					return true;
+
 				if (rootMenu.GetSubMenuByType(MenuPlayerManager) == null)
 				{
 					rootMenu.CreateSubMenu(MenuPlayerManager);
 				}
-				pManager = MenuPlayerManager.Cast(VPPAdminHud.Cast(GetVPPUIManager().GetMenuByType(VPPAdminHud)).GetSubMenuByType(MenuPlayerManager));
-				pManager.GetPlayerEntry(m_GUID64Input).SetSelected(m_ChkSelectPlayer.IsChecked());
-				pManager.SendForPlayerStats();
+				pManager = MenuPlayerManager.Cast(rootMenu.GetSubMenuByType(MenuPlayerManager));
+				if (pManager && pManager.GetPlayerEntry(m_GUID64Input))
+				{
+					pManager.GetPlayerEntry(m_GUID64Input).SetSelected(m_ChkSelectPlayer.IsChecked());
+					pManager.SendForPlayerStats();
+				}
 				return true;
 			break;
 			
@@ -333,8 +343,11 @@ class VPPESPTracker: ScriptedWidgetEventHandler
 		if (!m_CheckBox)
 			return;
 
-		EspToolsMenu espManager = EspToolsMenu.Cast(VPPAdminHud.Cast(GetVPPUIManager().GetMenuByType(VPPAdminHud)).GetSubMenuByType(EspToolsMenu));
-		
+		EspToolsMenu espManager;
+		VPPAdminHud chkHud = VPPAdminHud.Cast(GetVPPUIManager().GetMenuByType(VPPAdminHud));
+		if (chkHud)
+			espManager = EspToolsMenu.Cast(chkHud.GetSubMenuByType(EspToolsMenu));
+
 		if (m_CheckBox.IsChecked())
 		{
 			if (player)
@@ -430,7 +443,10 @@ class VPPESPTracker: ScriptedWidgetEventHandler
 				ls[1] = ls[1] + 0.3;
 				startPos  = player.CoordToParent(ls);
 				
-				espManager = EspToolsMenu.Cast(VPPAdminHud.Cast(GetVPPUIManager().GetMenuByType(VPPAdminHud)).GetSubMenuByType(EspToolsMenu));
+				VPPAdminHud espHud = VPPAdminHud.Cast(GetVPPUIManager().GetMenuByType(VPPAdminHud));
+				if (espHud)
+					espManager = EspToolsMenu.Cast(espHud.GetSubMenuByType(EspToolsMenu));
+
 				if (!player.IsAlive() && (espManager && !espManager.ShowDeadPlayers()))
 				{
 					espManager.RemoveTracker(this);
@@ -471,8 +487,38 @@ class VPPESPTracker: ScriptedWidgetEventHandler
 
 			if (m_ItemDistanceWidget)
 			{
-				m_ItemDistanceWidget.SetText( "[" + Math.Floor(CalcDistance()).ToString() + "m]" );
+				string distText = "[" + Math.Floor(CalcDistance()).ToString() + "m]";
+
+				//Health at a glance, tinted by the same thresholds as the vitals bars.
+				//Entity health is networked to nearby clients; the TransferValues vitals are
+				//only synced to the player who owns them, so they are just a fallback.
+				if (player && player.IsAlive())
+				{
+					float hp = -1;
+
+					float maxHp = player.GetMaxHealth("", "Health");
+					if (maxHp > 0)
+						hp = player.GetHealth("", "Health") / maxHp;
+
+					if (hp <= 0 && player.GetTransferValues())
+						hp = player.GetTransferValues().m_HealthClient;
+
+					//an alive player can't truly be at 0 health: that means we have no synced
+					//value, so show nothing rather than a wrong number
+					if (hp > 0)
+					{
+						hp = Math.Clamp(hp, 0.0, 1.0);
+						distText += " [" + Math.Round(hp * 100).ToString() + "%]";
+						m_ItemDistanceWidget.SetColor(VitalColor(hp));
+					}
+				}
+
+				m_ItemDistanceWidget.SetText(distText);
 			}
+
+			//Look arrows are drawn in 2D on the ESP canvas (see MissionGameplay.UpdateLookArrows).
+			//3D debug shapes render as hollow wireframes and scale in world metres, which looks
+			//nothing like a clean arrow.
 
 			BaseBuildingBase baseBuilding;
 			if (player || BaseBuildingBase.CastTo(baseBuilding, m_TrackerEntity) || BasebuildingHelperFuncs.IsItemStorageSafe(m_TrackerEntity))
@@ -480,7 +526,7 @@ class VPPESPTracker: ScriptedWidgetEventHandler
 				if (player)
 				{
 					//Check death
-					if (!player.IsAlive() && espManager.ShowDeadPlayers() && player.GetIdentity())
+					if (!player.IsAlive() && espManager && espManager.ShowDeadPlayers() && player.GetIdentity())
 					{
 						m_ItemNameWidget.SetText(player.GetIdentity().GetName() + " (Dead)");
 					}
@@ -521,8 +567,12 @@ class VPPESPTracker: ScriptedWidgetEventHandler
 
 			if (player && m_DetialedWidget)
 			{
-				m_RootWidget.FindAnyWidget("IconDead").Show(!player.IsAlive());
-				m_RootWidget.FindAnyWidget("StrDead").Show(!player.IsAlive());
+				Widget iconDead = m_RootWidget.FindAnyWidget("IconDead");
+				Widget strDead = m_RootWidget.FindAnyWidget("StrDead");
+				if (iconDead)
+					iconDead.Show(!player.IsAlive());
+				if (strDead)
+					strDead.Show(!player.IsAlive());
 
 				float hpPct = Math.Clamp(player.GetTransferValues().m_HealthClient, 0.0, 1.0);
 				float blPct = Math.Clamp(player.GetTransferValues().m_BloodClient, 0.0, 1.0);
@@ -582,6 +632,35 @@ class VPPESPTracker: ScriptedWidgetEventHandler
 		}
 	}
 
+	//---- look direction (used by MissionGameplay's 2D canvas arrow) ----
+	//Where the player is LOOKING: body yaw plus aim pitch.
+	//GetAimingAngleUD() returns DEGREES; feeding it to sin/cos as radians is what made the
+	//arrow stab through the floor before. Convert and clamp.
+	vector GetLookDirection()
+	{
+		if (!player)
+			return "0 0 0";
+
+		vector dir = player.GetDirection();
+		dir[1] = 0;
+		dir.Normalize();
+
+		float pitchDeg = player.GetAimingAngleUD();
+		if (pitchDeg != 0)
+		{
+			float pitchRad = Math.Clamp(pitchDeg, -75, 75) * Math.DEG2RAD;
+			dir = dir * Math.Cos(pitchRad);
+			dir[1] = Math.Sin(pitchRad);
+			dir.Normalize();
+		}
+		return dir;
+	}
+
+	SurvivorBase GetTrackedPlayer()
+	{
+		return player;
+	}
+
 	//design-system vital threshold tint (DesignSystem.md §1)
 	int VitalColor(float pct)
 	{
@@ -602,7 +681,7 @@ class VPPESPTracker: ScriptedWidgetEventHandler
 		if (m_MouseEventHold)
 			m_MouseEventHold.SetActive(false);
 
-		if (m_TrackerEntity)
+		if (m_TrackerEntity && m_MouseEventHold && m_MouseEventHold.GetMarker())
 		{
 			vector posMarker = m_MouseEventHold.GetMarker().GetPosition();
 			GetRPCManager().VSendRPC("RPC_TeleportManager", "TeleportEntity", new Param1<vector>(posMarker), true, NULL, m_TrackerEntity);
@@ -669,6 +748,9 @@ class VPPESPTracker: ScriptedWidgetEventHandler
 	
 	bool IsTrackedObject(Object obj)
 	{
+		if (!obj || !m_TrackerEntity)
+			return false;
+
 		return obj.GetNetworkIDString() == m_TrackerEntity.GetNetworkIDString();
 	}
 	

--- a/5_Mission/VPPAdminTools/GUI/SubMenus/MenuEspTools/EspToolsMenu.c
+++ b/5_Mission/VPPAdminTools/GUI/SubMenus/MenuEspTools/EspToolsMenu.c
@@ -20,6 +20,17 @@ class EspToolsMenu extends AdminHudSubMenu
 	private CheckBoxWidget   m_chkSelectAll; //Filter checkbox
 	CheckBoxWidget   		  m_ChkShowClassName;
 	CheckBoxWidget 			 m_ChkShowDeadPlayers;
+	CheckBoxWidget 			 m_ChkShowLookArrow;
+	private ButtonWidget	 m_BtnArrowColor;
+	private SliderWidget	 m_SliderArrowSize;
+	private bool			 m_PickingArrowColor;
+	private ref map<string,bool> m_AdminIds; //steam64 -> true, for gold admin names
+
+	//look-direction arrow settings (read by VPPESPTracker every frame)
+	static bool  s_ShowLookArrow = true;
+	static bool  s_EspActive     = false; //mirrors M_SCAN_ACTIVE for the canvas look-arrow pass
+	static int   s_ArrowColor    = ARGB(255, 0, 170, 255);
+	static float s_ArrowSize     = 1.0;
 	private int                 m_UpdateIntervalSeconds = 1;
 	private ref VPPDropDownMenu  m_IntervalDropDown;
 	private ref array<int>       m_IntervalPresets;
@@ -52,6 +63,9 @@ class EspToolsMenu extends AdminHudSubMenu
 
 		m_IntervalPresets = {1, 2, 3, 5, 10, 30};
 		m_IntervalLabels  = {"1s", "2s", "3s", "5s", "10s", "30s"};
+
+		m_AdminIds = new map<string,bool>;
+		GetRPCManager().AddRPC("RPC_VPPESPTools", "HandleAdminIds", this, SingeplayerExecutionType.Client);
 	}
 
 	void ~EspToolsMenu()
@@ -97,6 +111,11 @@ class EspToolsMenu extends AdminHudSubMenu
 		m_chkSelectAll = CheckBoxWidget.Cast(M_SUB_WIDGET.FindAnyWidget("chkSelectAll"));
 		m_ChkShowClassName = CheckBoxWidget.Cast(M_SUB_WIDGET.FindAnyWidget("ChkShowClassName"));
 		m_ChkShowDeadPlayers = CheckBoxWidget.Cast(M_SUB_WIDGET.FindAnyWidget("ChkShowDeadPlayers"));
+		m_ChkShowLookArrow = CheckBoxWidget.Cast(M_SUB_WIDGET.FindAnyWidget("ChkShowLookArrow"));
+		m_BtnArrowColor    = ButtonWidget.Cast(M_SUB_WIDGET.FindAnyWidget("BtnArrowColor"));
+		m_SliderArrowSize  = SliderWidget.Cast(M_SUB_WIDGET.FindAnyWidget("SliderArrowSize"));
+		LoadArrowSettings();
+		RequestAdminIds();
 		//update-interval preset dropdown (replaces the old edit box)
 		m_IntervalDropDown = new VPPDropDownMenu(M_SUB_WIDGET.FindAnyWidget("IntervalDropDownPanel"), m_IntervalLabels[0]);
 		foreach (string ivLabel : m_IntervalLabels)
@@ -182,6 +201,16 @@ class EspToolsMenu extends AdminHudSubMenu
 
 	void OnColorPicked(int index)
 	{
+		if (m_PickingArrowColor)
+		{
+			s_ArrowColor = VPPFilterEntry.ColorFromIndex(index);
+			if (m_BtnArrowColor)
+				m_BtnArrowColor.SetColor(s_ArrowColor);
+			SaveArrowSettings();
+			CloseColorPicker();
+			return;
+		}
+
 		if (m_ActiveColorFilter)
 		{
 			m_ActiveColorFilter.ApplyColorIndex(index);
@@ -195,6 +224,64 @@ class EspToolsMenu extends AdminHudSubMenu
 		if (m_ColorPickerPopup)
 			m_ColorPickerPopup.Show(false);
 		m_ActiveColorFilter = null;
+		m_PickingArrowColor = false;
+	}
+
+	//---- look-direction arrow settings ----
+	void LoadArrowSettings()
+	{
+		string val;
+		if (GetGame().GetProfileString("vppat_esp_arrowon", val) && val != "")
+			s_ShowLookArrow = (val == "1");
+		if (GetGame().GetProfileString("vppat_esp_arrowclr", val) && val != "")
+			s_ArrowColor = val.ToInt();
+		if (GetGame().GetProfileString("vppat_esp_arrowsize", val) && val != "")
+			s_ArrowSize = val.ToFloat();
+
+		if (m_ChkShowLookArrow)
+			m_ChkShowLookArrow.SetChecked(s_ShowLookArrow);
+		if (m_BtnArrowColor)
+			m_BtnArrowColor.SetColor(s_ArrowColor);
+		if (m_SliderArrowSize)
+			m_SliderArrowSize.SetCurrent(Math.Clamp(((s_ArrowSize - 0.4) / 1.6) * 100, 0, 100));
+	}
+
+	void SaveArrowSettings()
+	{
+		string chk = "0";
+		if (s_ShowLookArrow)
+			chk = "1";
+		GetGame().SetProfileString("vppat_esp_arrowon", chk);
+		GetGame().SetProfileString("vppat_esp_arrowclr", s_ArrowColor.ToString());
+		GetGame().SetProfileString("vppat_esp_arrowsize", s_ArrowSize.ToString());
+	}
+
+	void SyncArrowSettings()
+	{
+		if (m_ChkShowLookArrow)
+			s_ShowLookArrow = m_ChkShowLookArrow.IsChecked();
+		if (m_SliderArrowSize)
+			s_ArrowSize = 0.4 + ((m_SliderArrowSize.GetCurrent() / 100) * 1.6);
+	}
+
+	//---- admin highlight (gold names) ----
+	void RequestAdminIds()
+	{
+		GetRPCManager().VSendRPC("RPC_VPPESPTools", "GetAdminIds", new Param1<bool>(true), true);
+	}
+
+	void HandleAdminIds(CallType type, ParamsReadContext ctx, PlayerIdentity sender, Object target)
+	{
+		if (type != CallType.Client)
+			return;
+
+		Param1<ref array<string>> data;
+		if (!ctx.Read(data) || !data.param1)
+			return;
+
+		m_AdminIds.Clear();
+		foreach(string id : data.param1)
+			m_AdminIds.Set(id, true);
 	}
 
 	//update-interval preset dropdown selection
@@ -220,6 +307,8 @@ class EspToolsMenu extends AdminHudSubMenu
 			
 			if (M_SCAN_ACTIVE)
 			{
+				SyncArrowSettings();
+
 				vector startPos = GetGame().GetPlayer().GetPosition();
 				if (IsFreeCamActive())
 					startPos = VPPGetCurrentCameraPosition();
@@ -448,7 +537,22 @@ class EspToolsMenu extends AdminHudSubMenu
 							}
 						}
 					}
-					m_EspTrackers.Insert(man, new VPPESPTracker(pName, man, survivorFilter.m_Props.color));
+
+					//gold name for admins/superadmins
+					int trackerColor = survivorFilter.m_Props.color;
+					if (m_AdminIds.Count() > 0)
+					{
+						foreach(SyncPlayer adminChk : data)
+						{
+							if (adminChk && adminChk.m_PlayerName == pName && m_AdminIds.Contains(adminChk.m_UID))
+							{
+								trackerColor = ARGB(255, 255, 170, 0);
+								pName = "[A] " + pName;
+								break;
+							}
+						}
+					}
+					m_EspTrackers.Insert(man, new VPPESPTracker(pName, man, trackerColor));
 				}
 			}
 		}
@@ -483,9 +587,11 @@ class EspToolsMenu extends AdminHudSubMenu
 			m_btnToggle.SetColor(ARGB(255,255,0,0));
 			m_SliderEvent.ChangeColor(ARGB(255,255,0,0));
 			M_SCAN_ACTIVE = false;
+			s_EspActive = false;
 			ClearTrackers();
 		}else{
 			M_SCAN_ACTIVE = true;
+			s_EspActive = true;
 			m_btnToggle.SetColor(ARGB(255,0,255,0));
 			m_SliderEvent.ChangeColor(ARGB(255,0,255,0));
 			GetRPCManager().VSendRPC( "RPC_VPPESPTools", "ToggleESP", null, true, null); //for logging
@@ -508,6 +614,23 @@ class EspToolsMenu extends AdminHudSubMenu
 			CloseColorPicker();
 			return true;
 		}
+		if (w == m_BtnArrowColor)
+		{
+			if (m_ColorPickerPopup && m_ColorPickerPopup.IsVisible() && m_PickingArrowColor)
+			{
+				CloseColorPicker();
+				return true;
+			}
+			OpenColorPicker(null, m_BtnArrowColor);
+			m_PickingArrowColor = true;
+			return true;
+		}
+		if (w == m_ChkShowLookArrow)
+		{
+			s_ShowLookArrow = m_ChkShowLookArrow.IsChecked();
+			SaveArrowSettings();
+			return true;
+		}
 
 		switch(w)
 		{
@@ -515,9 +638,11 @@ class EspToolsMenu extends AdminHudSubMenu
 			if (M_SCAN_ACTIVE)
 			{
 				M_SCAN_ACTIVE = false;
+				s_EspActive = false;
 				ClearTrackers();
 			}else{
 				M_SCAN_ACTIVE = true;
+				s_EspActive = true;
 				GetRPCManager().VSendRPC( "RPC_VPPESPTools", "ToggleESP", null, true, null); //for logging
 			}
 			UpdateToggleVisual();
@@ -746,6 +871,11 @@ class EspToolsMenu extends AdminHudSubMenu
 			if (m_SliderEvent)
 				m_SliderEvent.ChangeColor(ARGB(255,255,0,0));
 		}
+	}
+
+	map<EntityAI, ref VPPESPTracker> GetTrackers()
+	{
+		return m_EspTrackers;
 	}
 
 	void ClearTrackers()

--- a/5_Mission/VPPAdminTools/missionGameplay.c
+++ b/5_Mission/VPPAdminTools/missionGameplay.c
@@ -168,13 +168,61 @@ modded class MissionGameplay
         return transformed_pos;
     }
 
+    //Same as above but reuses a screen size resolved once per frame. The widget query in
+    //TransformToScreenPos ran ~40x per player per frame, which is the bulk of the mesh ESP cost.
+    protected float m_CanvasW;
+    protected float m_CanvasH;
+
+    //Bone name -> index cache. Same for every human skeleton, so resolve once.
+    protected ref array<int> m_BoneIdxCache;
+    protected int m_HeadIdx = -2; //-2 = not resolved yet, -1 = missing bone
+    protected int m_NeckIdx = -2;
+
+    protected void BuildBoneIndexCache(PlayerBase p)
+    {
+        array<int> idx = new array<int>;
+        bool anyValid = false;
+
+        foreach(ESPBonesParams bp : m_EspBones)
+        {
+            int i1 = p.GetBoneIndexByName(bp.param1);
+            int i2 = p.GetBoneIndexByName(bp.param2);
+            idx.Insert(i1);
+            idx.Insert(i2);
+            if (i1 != -1 && i2 != -1)
+                anyValid = true;
+        }
+
+        if (!anyValid)
+            return; //bad entity: keep using live lookups rather than caching junk
+
+        m_BoneIdxCache = idx;
+        m_HeadIdx = p.GetBoneIndexByName("head");
+        m_NeckIdx = p.GetBoneIndexByName("neck");
+    }
+
+    vector ToScreen(vector pWorldPos)
+    {
+        vector screen_pos = GetGame().GetScreenPosRelative( pWorldPos );
+        vector out_pos;
+        out_pos[0] = screen_pos[0] * m_CanvasW;
+        out_pos[1] = screen_pos[1] * m_CanvasH;
+        return out_pos;
+    }
+
     private vector m_LastCamPos;
     private float  m_LastCamUpdate;
 
 	override void OnUpdate(float timeslice)
     {
         super.OnUpdate(timeslice);
+
+        //One clear per frame; the mesh skeleton and the look arrows share this canvas.
+        if (m_EspCanvasWidget)
+            m_EspCanvasWidget.Clear();
+
         UpdatePlayerMeshEsp();
+        UpdateLookArrows();
 
         //Free camera position updates
         /*
@@ -213,6 +261,94 @@ modded class MissionGameplay
             adminHud.HandleGameFocus();
     }
 
+    //Look arrows, drawn in 2D on the ESP canvas: --I>
+    //Screen space, so the arrow is a constant pixel size and stays crisp at any distance.
+    //(3D debug shapes render as hollow wireframes and scale in world metres - unusable here.)
+    protected void UpdateLookArrows()
+    {
+        if (!EspToolsMenu.s_ShowLookArrow || !EspToolsMenu.s_EspActive)
+            return;
+        if (!m_EspCanvas || !m_EspCanvasWidget)
+            return;
+
+        VPPAdminHud hud = VPPAdminHud.Cast(GetVPPUIManager().GetMenuByType(VPPAdminHud));
+        if (!hud)
+            return;
+
+        EspToolsMenu espMenu = EspToolsMenu.Cast(hud.GetSubMenuByType(EspToolsMenu));
+        if (!espMenu)
+            return;
+
+        m_EspCanvas.GetParent().GetScreenSize(m_CanvasW, m_CanvasH);
+
+        int color   = EspToolsMenu.s_ArrowColor;
+        float scale = EspToolsMenu.s_ArrowSize;
+
+        float rayMeters = 2.5 * scale; //how far the look ray reaches in the world
+        float width     = 2.0;
+
+        //ESP trackers are keyed by the tracked entity, so iterate the map's values
+        map<EntityAI, ref VPPESPTracker> trackers = espMenu.GetTrackers();
+        if (!trackers)
+            return;
+
+        foreach (EntityAI trackedEnt, VPPESPTracker tracker : trackers)
+        {
+            if (!tracker)
+                continue;
+
+            SurvivorBase p = tracker.GetTrackedPlayer();
+            if (!p || !p.IsAlive())
+                continue;
+
+            int headIdx = p.GetBoneIndexByName("head");
+            if (headIdx == -1)
+                continue;
+
+            vector dir = tracker.GetLookDirection();
+            if (dir.Length() < 0.01)
+                continue;
+
+            vector fromWS = p.GetBonePositionWS(headIdx) + "0 0.2 0";
+            vector toWS   = fromWS + (dir * rayMeters);
+
+            //both ends must be in front of the camera, else the projection flips
+            vector relA = GetGame().GetScreenPosRelative(fromWS);
+            vector relB = GetGame().GetScreenPosRelative(toWS);
+            if (relA[2] < 0 || relB[2] < 0)
+                continue;
+            if (relA[0] <= 0 || relA[0] >= 1 || relA[1] <= 0 || relA[1] >= 1)
+                continue; //player off screen
+
+            vector a = ToScreen(fromWS);
+            vector b = ToScreen(toWS);
+
+            //the ray itself: a real 3D line, projected - so it foreshortens correctly when the
+            //player looks toward or away from you
+            m_EspCanvasWidget.DrawLine(a[0], a[1], b[0], b[1], width, color);
+
+            //small arrowhead at the tip, sized in pixels so it stays crisp at any distance
+            float dx = b[0] - a[0];
+            float dy = b[1] - a[1];
+            float len = Math.Sqrt((dx * dx) + (dy * dy));
+            if (len < 1)
+                continue; //ray points straight at/away from us: nothing readable to cap
+
+            dx = dx / len;
+            dy = dy / len;
+            float px = -dy;
+            float py = dx;
+
+            float headLen = 9;
+            float headW   = 5;
+            float bx = b[0] - (dx * headLen);
+            float by = b[1] - (dy * headLen);
+
+            m_EspCanvasWidget.DrawLine(b[0], b[1], bx + (px * headW), by + (py * headW), width, color);
+            m_EspCanvasWidget.DrawLine(b[0], b[1], bx - (px * headW), by - (py * headW), width, color);
+        }
+    }
+
     protected void UpdatePlayerMeshEsp()
     {
         if (!m_MeshEspToggled)
@@ -223,26 +359,40 @@ modded class MissionGameplay
             return;
 
         int color = ARGBF(1, 1, 0, 0);
-        m_EspCanvasWidget.Clear();
-        if (GetVPPUIManager().GetMenuByType(VPPAdminHud))
-        {
-            EspToolsMenu espMenu = EspToolsMenu.Cast(VPPAdminHud.Cast(GetVPPUIManager().GetMenuByType(VPPAdminHud)).GetSubMenuByType(EspToolsMenu));
-            if (!espMenu)
-            VPPAdminHud.Cast(GetVPPUIManager().GetMenuByType(VPPAdminHud)).CreateSubMenu(EspToolsMenu);
 
-            espMenu = EspToolsMenu.Cast(VPPAdminHud.Cast(GetVPPUIManager().GetMenuByType(VPPAdminHud)).GetSubMenuByType(EspToolsMenu));
-            VPPFilterEntry pFilter = espMenu.GetFilter("SurvivorBase");
-            if (pFilter)
-                color = pFilter.GetFilterColor();
+        VPPAdminHud meshHud = VPPAdminHud.Cast(GetVPPUIManager().GetMenuByType(VPPAdminHud));
+        if (meshHud)
+        {
+            EspToolsMenu espMenu = EspToolsMenu.Cast(meshHud.GetSubMenuByType(EspToolsMenu));
+            if (!espMenu)
+            {
+                meshHud.CreateSubMenu(EspToolsMenu);
+                espMenu = EspToolsMenu.Cast(meshHud.GetSubMenuByType(EspToolsMenu));
+            }
+
+            if (espMenu)
+            {
+                VPPFilterEntry pFilter = espMenu.GetFilter("SurvivorBase");
+                if (pFilter)
+                    color = pFilter.GetFilterColor();
+            }
         }
 
-        array<Man> players = new array<Man>;
-        players = ClientData.m_PlayerBaseList;
+        //resolve the canvas size once per frame instead of once per bone (see ToScreen)
+        m_EspCanvas.GetParent().GetScreenSize(m_CanvasW, m_CanvasH);
+        vector camPos = GetGame().GetCurrentCameraPosition();
+
+        //ClientData.m_PlayerBaseList is already an array; the old code allocated a new one
+        //every frame and immediately threw it away.
+        array<Man> players = ClientData.m_PlayerBaseList;
+        if (!players)
+            return;
+
         foreach(Man man : players)
         {
             if (!man)
                 continue;
-            if(man == GetGame().GetPlayer())
+            if(man == GetGame().GetPlayer() && !IsFreeCamActive()) //own skeleton visible from freecam only
                 continue;
 
             PlayerBase playerPB = PlayerBase.Cast(man);
@@ -256,32 +406,63 @@ modded class MissionGameplay
             else if(ScreenPosRelative[2] < 0)
                 continue;
 
+            //corpses draw dim grey; line width thins out with distance for a cleaner look
+            int drawColor = color;
+            if (!playerPB.IsAlive())
+                drawColor = ARGB(255, 150, 150, 150);
+
+            float camDist = vector.Distance(camPos, playerPB.GetPosition());
+            float width = Math.Clamp(2.5 - (camDist * 0.004), 1.0, 2.5);
+
+            //Bone indices are identical for every human skeleton, so resolve the names once
+            //instead of ~40 string lookups per player per frame. Falls back to live lookups
+            //if the cache could not be built.
+            if (!m_BoneIdxCache)
+                BuildBoneIndexCache(playerPB);
+
+            int b = 0;
             foreach(ESPBonesParams params : m_EspBones)
             {
-                int fromIdx = playerPB.GetBoneIndexByName(params.param1);
-                int toIdx   = playerPB.GetBoneIndexByName(params.param2);
+                int fromIdx;
+                int toIdx;
+                if (m_BoneIdxCache)
+                {
+                    fromIdx = m_BoneIdxCache[b];
+                    toIdx   = m_BoneIdxCache[b + 1];
+                }
+                else
+                {
+                    fromIdx = playerPB.GetBoneIndexByName(params.param1);
+                    toIdx   = playerPB.GetBoneIndexByName(params.param2);
+                }
+                b = b + 2;
 
-                vector fromPos = TransformToScreenPos(playerPB.GetBonePositionWS(fromIdx));
-                vector toPos   = TransformToScreenPos(playerPB.GetBonePositionWS(toIdx));
-                m_EspCanvasWidget.DrawLine(toPos[0], toPos[1], fromPos[0], fromPos[1], 2, color);
+                vector fromPos = ToScreen(playerPB.GetBonePositionWS(fromIdx));
+                vector toPos   = ToScreen(playerPB.GetBonePositionWS(toIdx));
+                m_EspCanvasWidget.DrawLine(toPos[0], toPos[1], fromPos[0], fromPos[1], width, drawColor);
             }
 
-            //Draw Face
-            int headIdx = playerPB.GetBoneIndexByName("head");
-            int neckIdx = playerPB.GetBoneIndexByName("neck");
-            vector fpos = TransformToScreenPos(playerPB.GetBonePositionWS(headIdx));
-            vector npos = TransformToScreenPos(playerPB.GetBonePositionWS(neckIdx));
+            //Draw Face (12 segments instead of 360 -> same look, huge fps win)
+            int headIdx = m_HeadIdx;
+            int neckIdx = m_NeckIdx;
+            if (headIdx == -2 || neckIdx == -2) //cache not built
+            {
+                headIdx = playerPB.GetBoneIndexByName("head");
+                neckIdx = playerPB.GetBoneIndexByName("neck");
+            }
+            vector fpos = ToScreen(playerPB.GetBonePositionWS(headIdx));
+            vector npos = ToScreen(playerPB.GetBonePositionWS(neckIdx));
 
-            float size = 1 * fpos[1] - npos[1];
-            for(int j = 0; j < 360; j++)
+            float size = Math.Clamp(Math.AbsFloat(fpos[1] - npos[1]), 2, 120);
+            for(int j = 0; j < 360; j = j + 30)
             {
                 float x1 = fpos[0] + (size * Math.Cos(j * Math.DEG2RAD));
                 float y1 = fpos[1] + (size * Math.Sin(j * Math.DEG2RAD));
 
-                float x2 = fpos[0] + (size * Math.Cos((j + 1) * Math.DEG2RAD));
-                float y2 = fpos[1] + (size * Math.Sin((j + 1) * Math.DEG2RAD));
+                float x2 = fpos[0] + (size * Math.Cos((j + 30) * Math.DEG2RAD));
+                float y2 = fpos[1] + (size * Math.Sin((j + 30) * Math.DEG2RAD));
 
-                m_EspCanvasWidget.DrawLine(x1, y1, x2, y2, 2, color);
+                m_EspCanvasWidget.DrawLine(x1, y1, x2, y2, width, drawColor);
             }
         }
     }

--- a/GUI/Layouts/EspToolsUI/EspToolsMenu.layout
+++ b/GUI/Layouts/EspToolsUI/EspToolsMenu.layout
@@ -836,6 +836,90 @@ FrameWidgetClass rootFrame {
         }
        }
       }
+      CheckBoxWidgetClass ChkShowLookArrow {
+       ignorepointer 0
+       position 0.02 254
+       size 0.7 22
+       hexactpos 0
+       vexactpos 1
+       hexactsize 0
+       vexactsize 1
+       style VPPCheckBox
+       font "gui/fonts/sdf_MetronLight72"
+       checked 1
+       {
+        TextWidgetClass LblShowLookArrow {
+         ignorepointer 1
+         position 30 0
+         size 1 1
+         valign center_ref
+         hexactpos 1
+         vexactpos 1
+         hexactsize 0
+         vexactsize 0
+         text "Look direction arrows"
+         font "gui/fonts/sdf_MetronLight72"
+         "exact text" 1
+         "exact text size" 14
+         "size to text h" 1
+         "size to text v" 1
+         "text valign" center
+        }
+       }
+      }
+      ButtonWidgetClass BtnArrowColor {
+       ignorepointer 0
+       color 0 0.667 1 1
+       position 0.86 254
+       size 34 22
+       hexactpos 0
+       vexactpos 1
+       hexactsize 1
+       vexactsize 1
+       style VPPButton
+       font "gui/fonts/sdf_MetronLight72"
+      }
+      SliderWidgetClass SliderArrowSize {
+       color 1 1 1 1
+       position 0.015 286
+       size 0.97 22
+       hexactpos 0
+       vexactpos 1
+       hexactsize 0
+       vexactsize 1
+       scriptclass "SliderEventHandler"
+       style VPPSlider
+       maximum 100
+       current 30
+       vertical 0
+       flipped 0
+       "fill in" 1
+       {
+        TextWidgetClass SliderArrowSizeDisplay {
+         ignorepointer 1
+         color 1 1 1 1
+         size 1 1
+         halign center_ref
+         valign center_ref
+         hexactpos 0
+         vexactpos 0
+         hexactsize 0
+         vexactsize 0
+         style None
+         text "ArrowSize:[30]"
+         font "gui/fonts/sdf_MetronLight72"
+         "outline size" 2
+         "outline color" 0 0 0 0.784
+         "bold text" 1
+         "exact text" 1
+         "exact text size" 14
+         "size to text h" 1
+         "size to text v" 1
+         "text halign" center
+         "text valign" center
+        }
+       }
+      }
       ButtonWidgetClass btnDelRadius {
        ignorepointer 0
        color 1 1 1 1


### PR DESCRIPTION
…system

Spectate
- The camera froze permanently when the spectated player died. It now keeps following the body, and keeps the network bubble alive if the target entity disappears entirely.
- While the target is dead or gone, the client asks the server to re-attach every 5 seconds (new ReSpectatePlayer RPC) until the admin exits or picks a new target, so respawns and reconnects are picked up automatically.
- Exiting spectate now destroys the camera; it previously leaked and its retry loop kept running.
- The Spectate button works while already spectating to switch targets: the server falls back to the sender identity when the admin has no player object, and the client re-targets the active camera instead of creating a second one.

ESP
- New: a 3D look-direction arrow in front of each tracked player showing which way they are facing. Drawn with one-frame debug shapes (nothing to clean up), visible through walls, alive players within 150m. Toggle, colour (shared swatch picker) and size slider added to the ESP menu; settings persist in the profile.
- Admins and user-group members show gold with an [A] prefix in player ESP. The client fetches the id list through a new permission-gated GetAdminIds RPC.
- Skeleton ESP: the head circle was 360 line segments per player per frame, now 12 (visually identical, far cheaper). Line width scales with distance and corpses draw grey. Own skeleton is drawn when freecam is active.
- Crash fixes in VPPESPTracker: several unguarded null dereferences that crash the client when the admin HUD or ESP submenu is closed while trackers are still updating (chained VPPAdminHud/EspToolsMenu casts, missing IconDead/ StrDead widgets, null player entry on the select checkbox, null drag marker on teleport, null arguments in IsTrackedObject).

Flag system (new server plugin, off/on via config)
- Flags a kill for admin review when the killer has less than MinPlaytimeHours tracked on this server AND the kill is either at/above LongRangeKillMeters or a head/brain hit at any range.
- Config at ConfigurablePlugins/FlagSystem.json: Enabled, thresholds, ExemptAdmins (default on), ExemptIds, NotifyOnlineAdmins, DiscordWebhookURL.
- Flags are stored per player in FlagSystem/FlagDatabase.json, logged, sent to online admins in-game, and optionally posted to Discord. The flagged player is never told.
- "See Flags" action in the Player Manager shows a player's report (playtime, exempt status, recent flags) behind a new PlayerManager:SeeFlags permission.
- Playtime is flushed on the autosave timer, not only on clean disconnect, so a crash does not wipe tracked sessions. Kill attribution only uses hits from the last 15 seconds, and records distance at impact rather than at the death event.