### PR TITLE
Added "Dynamic" Sidebar

### DIFF
--- a/5_Mission/VPPAdminTools/GUI/VPPAdminHud.c
+++ b/5_Mission/VPPAdminTools/GUI/VPPAdminHud.c
@@ -21,6 +21,12 @@ class VPPAdminHud extends VPPScriptedMenu
 	protected float   m_StartX, m_StartY;
 	protected float   m_EndX,   m_EndY;
 
+	protected int     m_BaseRows;
+	protected int     m_MaxExtraRows      = 3;
+	protected float   m_SafeScreenMargin  = 64.0;
+	protected float   m_IconsBaseW, m_IconsBaseH;
+	protected float   m_WrapBaseW,  m_WrapBaseH;
+
 	static ref ScriptInvoker m_OnPermissionsChanged = new ScriptInvoker(); //invoker
 	
 	void VPPAdminHud()
@@ -44,6 +50,7 @@ class VPPAdminHud extends VPPScriptedMenu
 		InsertButton("MenuWebHooks", "Webhooks", "set:dayz_gui_vpp image:vpp_icon_webHooks", "#VSTR_TOOLTIP_WEBHOOKS");
 		InsertButton("MenuXMLEditor", "XML Editor", "set:dayz_gui_vpp image:vpp_icon_xml_editor", "#VSTR_TOOLTIP_XMLEDITOR");
 		InsertButton("MenuSpectateTools", "Spectate", "set:dayz_gui_vpp image:vpp_icon_esp", "#VSTR_TOOLTIP_SPECTATE");
+		m_BaseRows = m_DefinedButtons.Count();
 		DefineButtons();
 		//----
 		//Compile Permissions needed by buttons registered.
@@ -74,6 +81,9 @@ class VPPAdminHud extends VPPScriptedMenu
 			m_IconsPanel 		= layoutRoot.FindAnyWidget("IconsPanel");
 	  	  	m_WrapSpacerWidget  = WrapSpacerWidget.Cast(layoutRoot.FindAnyWidget("WrapSpacerWidget"));
 			m_Init = true;
+
+			m_IconsPanel.GetSize(m_IconsBaseW, m_IconsBaseH);
+			m_WrapSpacerWidget.GetSize(m_WrapBaseW, m_WrapBaseH);
 
 	        m_IconsPanel.GetPos(m_StartX, m_StartY);
 
@@ -127,6 +137,33 @@ class VPPAdminHud extends VPPScriptedMenu
 		}
 	}
 		
+	private void UpdateToolbarCapacity()
+	{
+		if (!layoutRoot || !m_IconsPanel || !m_WrapSpacerWidget || m_BaseRows <= 0 || m_IconsBaseH <= 0 || m_WrapBaseH <= 0)
+			return;
+
+		float screenW, screenH;
+		layoutRoot.GetScreenSize(screenW, screenH);
+		if (screenH <= 0)
+			return;
+		float rowH = (m_IconsBaseH * screenH) / m_BaseRows;
+
+		int visibleRows = 0;
+		foreach(VPPButtonProperties data : m_DefinedButtons)
+		{
+			if (HasPermission(data.param1))
+				visibleRows++;
+		}
+
+		int maxExtra  = Math.Clamp(Math.Floor((screenH - m_SafeScreenMargin) / rowH) - m_BaseRows, 0, m_MaxExtraRows);
+		int extraRows = Math.Clamp(visibleRows - m_BaseRows, 0, maxExtra);
+
+		float panelH = m_IconsBaseH + ((extraRows * rowH) / screenH);
+		m_IconsPanel.SetSize(m_IconsBaseW, panelH);
+		m_WrapSpacerWidget.SetSize(m_WrapBaseW, (m_WrapBaseH * m_IconsBaseH) / panelH);
+		m_IconsPanel.Update();
+	}
+
 	void VerifyButtonsPermission(CallType type, ParamsReadContext ctx, PlayerIdentity sender, Object target)
 	{
 		Param1<ref map<string,bool>> data;
@@ -141,6 +178,7 @@ class VPPAdminHud extends VPPScriptedMenu
 				CreateButtons(); //Creates UI part of things regardless of permission(s)
 			}
 			VPPAdminHud.m_OnPermissionsChanged.Invoke(m_ButtonPerms);
+			UpdateToolbarCapacity();
 		}
 	}
 


### PR DESCRIPTION
Improves the VPP Admin Tools sidebar so extension modules do not immediately require scrolling.

Changes

- Preserves the original sidebar size when only stock VPP modules are visible.
- Expands the sidebar for up to three additional visible modules when screen height permits.
- Limits smaller displays to a safe number of additional rows.
- Retains the existing scrollbar for modules beyond the available capacity.
- Uses VPP’s existing module registration and permission state.
- Hidden modules do not create unused space.
- Preserves existing button sizing, ordering, width, hover behavior, and module functionality.

Responsive behavior

- 1366x768: up to 2 additional rows before scrolling.
- 1920x1080 and taller: up to 3 additional rows before scrolling.
- Maintains a safe bottom-screen margin to prevent the sidebar from extending off-screen.

Testing

Tested locally with CF, VPP Admin Tools, and VPP-Att-Addon. Server and client Game, World, and Mission modules compiled and initialized without script errors.